### PR TITLE
Add MPS support for Gradio demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ OpenVoice has been powering the instant voice cloning capability of [myshell.ai]
 
 ## Common Issues
 
-Please see [QnA](QA.md) for common questions and answers. We will regularly update the question and answer list.
+Please see [Q&A](QA.md) for common questions and answers. We will regularly update the question and answer list.
 
 ## Installation
 Clone this repo, and run
@@ -62,7 +62,24 @@ conda activate openvoice
 conda install pytorch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1 pytorch-cuda=11.7 -c pytorch -c nvidia
 pip install -r requirements.txt
 ```
-Download the checkpoint from [here](https://myshell-public-repo-hosting.s3.amazonaws.com/checkpoints_1226.zip) and extract it to the `checkpoints` folder 
+Download the checkpoint from [here](https://myshell-public-repo-hosting.s3.amazonaws.com/checkpoints_1226.zip) and extract it to the `checkpoints` folder
+
+## Apple Silicon (MPS) Support
+
+Apple Silicon (MPS) GPUs are partially supported, however not all operations are available due to the lack of complete MPS support in PyTorch.
+
+Until full MPS support has been added to PyTorch, please prepend all your commands with:
+
+```bash
+PYTORCH_ENABLE_MPS_FALLBACK=1 python ***.py
+```
+
+Or, in Python:
+
+```python
+import os
+os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+```
 
 ## Usage
 

--- a/api.py
+++ b/api.py
@@ -14,9 +14,17 @@ from models import SynthesizerTrn
 class OpenVoiceBaseClass(object):
     def __init__(self, 
                 config_path, 
-                device='cuda:0'):
+                device=None):
+        if device == None:
+            device = 'cpu'
+            if torch.cuda.is_available():
+                device = 'cuda'
+            if torch.backends.mps.is_available():
+                device = 'mps'
         if 'cuda' in device:
             assert torch.cuda.is_available()
+        if 'mps' in device:
+            assert torch.backends.mps.is_available()
 
         hps = utils.get_hparams_from_file(config_path)
 

--- a/openvoice_app.py
+++ b/openvoice_app.py
@@ -14,7 +14,11 @@ args = parser.parse_args()
 en_ckpt_base = 'checkpoints/base_speakers/EN'
 zh_ckpt_base = 'checkpoints/base_speakers/ZH'
 ckpt_converter = 'checkpoints/converter'
-device = 'cuda' if torch.cuda.is_available() else 'cpu'
+device = 'cpu'
+if torch.cuda.is_available():
+    device = 'cuda'
+if torch.backends.mps.is_available():
+    device = 'mps'
 output_dir = 'outputs'
 os.makedirs(output_dir, exist_ok=True)
 


### PR DESCRIPTION
Hi,
Thank you for creating this amazing software. Looking forward to the license change (#16)!

This PR adds support for Apple Silicon (M1, M2, M3, etc) GPU devices (on arm64 Macs) using MPS.

However, there are some limitations on Apple Silicon devices. Please see the modified README for details:

> Apple Silicon (MPS) GPUs are partially supported, however not all operations are available due to the lack of complete MPS support in PyTorch.
> 
> Until full MPS support has been added to PyTorch, please prepend all your commands with:
> 
> ```bash
> PYTORCH_ENABLE_MPS_FALLBACK=1 python ***.py
> ```
> 
> Or, in Python:
> 
> ```python
> import os
> os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
> ```

Please let me know if you have any questions or comments!