### PR TITLE
Add ffmpeg to the requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ cn2an==0.5.22
 jieba==0.42.1
 gradio==3.48.0
 langid==1.1.6
+ffmpeg


### PR DESCRIPTION
I just encountered the 
> FileNotFoundError: [WinError 2] The system cannot find the file specified

when running demo_part1.ipynb and after searching it turns out that `conda install ffmpeg` solves the error.

It's also addressed here #34 and many others encounter the same problem before noticing that it's already addressed in the issues section, so it will save a lot of time if it's installed with the other packages.