### PR TITLE
feat: docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,71 @@
+FROM python:3.10-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    ffmpeg \
+    git \
+    gnupg2 \
+    unzip \
+    wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add nvidia package repositories
+RUN apt-get update && \
+    apt-get install -y gnupg2 && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64/3bf863cc.pub | apt-key add - && \
+    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64 /" > /etc/apt/sources.list.d/cuda.list && \
+    apt-get update
+
+# Install CUDA 12.1
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    cuda-toolkit-12-1 \
+    libcublas-12-1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY cudnn-linux-x86_64-8.9.7.29_cuda12-archive.tar.xz /tmp/
+
+# Extract and install cuDNN 8.9.7
+RUN tar -xvf /tmp/cudnn-linux-x86_64-8.9.7.29_cuda12-archive.tar.xz -C /tmp && \
+    cp -P /tmp/cudnn-linux-x86_64-8.9.7.29_cuda12-archive/include/cudnn*.h /usr/local/cuda-12.1/include/ && \
+    cp -P /tmp/cudnn-linux-x86_64-8.9.7.29_cuda12-archive/lib/libcudnn* /usr/local/cuda-12.1/lib64/ && \
+    chmod a+r /usr/local/cuda-12.1/include/cudnn*.h /usr/local/cuda-12.1/lib64/libcudnn*
+
+# Set environment variables for CUDA and cuDNN
+ENV PATH=/usr/local/cuda-12.1/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda-12.1/lib64:${LD_LIBRARY_PATH}
+
+# Create a symlink for libcublas.so.11
+RUN ln -s /usr/local/cuda-12.1/lib64/libcublas.so.12 /usr/local/cuda-12.1/lib64/libcublas.so.11
+
+WORKDIR /workspace
+
+COPY . /workspace
+
+RUN pip install --upgrade pip
+
+RUN pip install -r requirements.txt
+
+# Install pytorch with CUDA 12.1 support
+RUN pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu121
+
+RUN pip install git+https://github.com/violetdenim/wavmark.git
+RUN pip install git+https://github.com/myshell-ai/MeloTTS.git
+
+RUN python -m unidic download
+
+RUN pip install -e .
+
+RUN pip install jupyter
+
+# Port for jupyter
+EXPOSE 8888
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Set the entrypoint for the container, see entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+download_and_unzip() {
+    url=$1
+    output_zip=$2
+    output_dir=$3
+    
+    wget $url -O $output_zip && \
+    mkdir -p /tmp/extract_temp && \
+    unzip $output_zip -d /tmp/extract_temp && \
+    first_folder=$(find /tmp/extract_temp -mindepth 1 -maxdepth 1 -type d | head -n 1) && \
+    mkdir -p $output_dir && \
+    mv $first_folder/* $output_dir/ && \
+    rm -rf /tmp/extract_temp && \
+    rm $output_zip
+}
+
+if [ "$1" = "v1" ]; then
+    echo "Downloading v1 checkpoints..."
+    download_and_unzip "https://myshell-public-repo-hosting.s3.amazonaws.com/openvoice/checkpoints_1226.zip" "checkpoints_1226.zip" "/workspace/checkpoints_v1"
+elif [ "$1" = "v2" ]; then
+    echo "Downloading v2 checkpoints..."
+    download_and_unzip "https://myshell-public-repo-hosting.s3.amazonaws.com/openvoice/checkpoints_v2_0417.zip" "checkpoints_v2_0417.zip" "/workspace/checkpoints_v2"
+else
+    echo "Downloading both v1 and v2 checkpoints..."
+    download_and_unzip "https://myshell-public-repo-hosting.s3.amazonaws.com/openvoice/checkpoints_1226.zip" "checkpoints_1226.zip" "/workspace/checkpoints_v1"
+    download_and_unzip "https://myshell-public-repo-hosting.s3.amazonaws.com/openvoice/checkpoints_v2_0417.zip" "checkpoints_v2_0417.zip" "/workspace/checkpoints_v2"
+fi
+echo "Starting Jupyter Notebook..."
+jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser --allow-root --NotebookApp.notebook_dir='/workspace' &
+
+wait


### PR DESCRIPTION
### **Features:**

1. Includes CUDA 12.1 and cuDNN 8.9.7 & CUDA/cuDNN installation process. Solved: #215 and #225
2. Optimized Docker layer caching for faster builds
3. Added ability to download only necessary checkpoints. Solved: time and space
4. Switched base image to python:3.10-slim

_This setup has been thoroughly tested to ensure stability and performance.

### **tl;dr**
Hey everyone,

I've been working on improving the Docker setup for OpenVoice, and I think these changes will make it much easier to run in a containerized environment.

The main issue I've seen is with CUDA and cuDNN versions not matching up, causing errors. In this Dockerfile, I've included CUDA 12.1 and cuDNN 8.9.7, which work well with the latest PyTorch that supports CUDA 12. This should help eliminate those errors.

Another improvement is the entrypoint shell script. Additionally, you can now download only the checkpoints you need: it will only download the checkpoints for the specified version, saving time and bandwidth.

I've also optimized the Docker layer cache. I rearranged some commands so that if only the local files change, Docker can reuse the base layers that have all the lengthy installations. This should speed up your builds when you're making changes to your local setup.

In summary, smoother, faster, and less prone to errors. It's now easier to spin up different versions and notebooks without CUDA issues or long installations.

This setup has been thoroughly tested to ensure stability and performance.

Give it a try and let me know how it goes! I'm always happy to hear feedback and suggestions. I think this will be a big improvement for the OpenVoice experience.

Happy Dockerizing! 🐳
Vlad

**Running:**
![image](https://github.com/myshell-ai/OpenVoice/assets/48068368/2965e441-87f5-4a6e-a410-34f0289f80cd)
**Results:**
![image](https://github.com/myshell-ai/OpenVoice/assets/48068368/ee2f3294-a43e-43b8-8955-afb1ab18c990)
