### PR TITLE
FIX:Demo supports Apple Silicon, resolving issues #18,#272,#9

### DIFF
--- a/demo_part3.ipynb
+++ b/demo_part3.ipynb
@@ -105,8 +105,8 @@
     "        speaker_key = speaker_key.lower().replace('_', '-')\n",
     "        \n",
     "        source_se = torch.load(f'checkpoints_v2/base_speakers/ses/{speaker_key}.pth', map_location=device)\n",
-    "        if torch.backends.mps.is_available() and device == 'cpu':\n
-    "            torch.backends.mps.is_available = lambda: False\n
+    "        if torch.backends.mps.is_available() and device == 'cpu':\n",
+    "            torch.backends.mps.is_available = lambda: False\n",
     "        model.tts_to_file(text, speaker_id, src_path, speed=speed)\n",
     "        save_path = f'{output_dir}/output_v2_{speaker_key}.wav'\n",
     "\n",

--- a/demo_part3.ipynb
+++ b/demo_part3.ipynb
@@ -105,6 +105,8 @@
     "        speaker_key = speaker_key.lower().replace('_', '-')\n",
     "        \n",
     "        source_se = torch.load(f'checkpoints_v2/base_speakers/ses/{speaker_key}.pth', map_location=device)\n",
+    "        if torch.backends.mps.is_available() and device == 'cpu':\n
+    "            torch.backends.mps.is_available = lambda: False\n
     "        model.tts_to_file(text, speaker_id, src_path, speed=speed)\n",
     "        save_path = f'{output_dir}/output_v2_{speaker_key}.wav'\n",
     "\n",


### PR DESCRIPTION
FIX：  
https://github.com/myshell-ai/OpenVoice/issues/18  
https://github.com/myshell-ai/MeloTTS/issues/9  
https://github.com/myshell-ai/OpenVoice/issues/272

I successfully ran the v2 example on Mac M1 using monkey-patching method.

The main cause of the RuntimeError: "Placeholder storage has not been allocated on MPS device!" is that when the example uses `model.tts_to_file(text, speaker_id, src_path, speed=speed)` in melo/chinese_bert.py, it attempts to use MPS type.

Solution: Add a patch specifically for Apple Silicon by setting `torch.backends.mps.is_available = lambda: False`:

```python
source_se = torch.load(f'checkpoints_v2/base_speakers/ses/{speaker_key}.pth', map_location=device)
if torch.backends.mps.is_available() and device == 'cpu':
    torch.backends.mps.is_available = lambda: False  # Force disable MPS
model.tts_to_file(text, speaker_id, src_path, speed=speed)
save_path = f'{output_dir}/output_v2_{speaker_key}.wav'
```